### PR TITLE
general: T8595: add CLAUDE.md

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/.cursorrules
+++ b/.cursorrules
@@ -1,1 +1,0 @@
-CLAUDE.md

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,1 @@
+../CLAUDE.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,3 @@ Mirror twin: `VyOS-Networks/live-boot`. Canonical side is here. Mirror pipeline 
 
 - Long-term plan (per README): retire this fork. Don't add features here that could equally live in `vyos-build`'s chroot overlay.
 - Any change touching `components/9990-vyos.sh` affects boot-time config mount on every VyOS install — coordinate with `vyos-1x` config-loading code.
-
----
-
-This file is mirrored on Confluence: [`vyos/live-boot`](https://internal.confluence.vyos.com/wiki/spaces/VYOS/pages/818053227). The Confluence page also carries the per-repo audit data (settings, workflows, secret counts, hygiene) that complements this CLAUDE.md. Edit either side; resync via the documentation pipeline.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,52 @@
+# CLAUDE.md
+
+## Project purpose
+
+VyOS fork of Debian's `live-boot` — the initramfs/boot scripts that bring up a Debian Live system. The VyOS extensions mount the VyOS config directories during system startup (see `components/9990-vyos.sh`). Required for the entire VyOS image to boot, even on 1.4. Ships Debian packages `live-boot`, `live-boot-doc`, `live-boot-initramfs-tools`.
+
+## Tech stack
+
+- POSIX shell + Roff manpages.
+- Plain `Makefile` (no autotools).
+- Debian packaging in `debian/`.
+
+## Build / test / run
+
+```sh
+make           # default target builds + lints scripts
+make test      # syntax check across backend/frontend/components scripts
+dpkg-buildpackage -us -uc
+```
+
+`SCRIPTS = backend/*/* frontend/* components/*`. The `Makefile` enforces shell syntax via `sh -n` per script.
+
+## Repository layout
+
+- `backend/` — initramfs-tools and similar backend integration.
+- `frontend/` — user-facing helpers.
+- `components/` — boot-time hooks; `9990-vyos.sh` is the VyOS hook for config mount.
+- `manpages/` — Roff manpages with i18n PO files under `manpages/po/`.
+- `debian/` — packaging.
+
+## Cross-repo context
+
+Pre-dep of the live ISO. Consumed by `vyos/vyos-live-build` (the `live-build` fork) which is in turn consumed by `vyos/vyos-build` for ISO assembly. Listed in `VyOS-Networks/vyos-build-packages/repos.toml`. README explicitly notes the long-term goal of dropping this fork in favour of upstream Debian `live-build` plus added files in the `vyos-build` chroot.
+
+## Conventions
+
+- Default branch `current`. LTS branches `sagitta`/`circinus`/`equuleus` for backports.
+- Commit / PR title format: `component: T12345: description` (Phorge task ID at https://vyos.dev) — enforced via `vyos/.github` reusables (see workflows below).
+- Active workflows: `cla-check.yml`, `pr-mirror-repo-sync.yml`, `trigger-rebuild-repo-package.yml`. So this repo IS wired into the mirror pipeline (sends PRs to `VyOS-Networks/live-boot`) and the rebuild-dispatch chain (notifies `vyos-build-packages` to rebuild on merge).
+
+## Mirror relationship
+
+Mirror twin: `VyOS-Networks/live-boot`. Canonical side is here. Mirror pipeline is **active** — merges to `current` propagate via `pr-mirror-repo-sync.yml`.
+
+## Notes for future contributors
+
+- Long-term plan (per README): retire this fork. Don't add features here that could equally live in `vyos-build`'s chroot overlay.
+- Any change touching `components/9990-vyos.sh` affects boot-time config mount on every VyOS install — coordinate with `vyos-1x` config-loading code.
+
+---
+
+This file is mirrored on Confluence: [`vyos/live-boot`](https://internal.confluence.vyos.com/wiki/spaces/VYOS/pages/818053227). The Confluence page also carries the per-repo audit data (settings, workflows, secret counts, hygiene) that complements this CLAUDE.md. Edit either side; resync via the documentation pipeline.


### PR DESCRIPTION
## Summary

Adds a single source of truth for repo-level agent instructions, plus three symlinks so different agentic tools all read the same content from one canonical file.

**Files added:**

| Path | Type | Consumed by |
|---|---|---|
| `CLAUDE.md` | real file | Claude Code, Anthropic agents |
| `AGENTS.md` | symlink → `CLAUDE.md` | tools that follow the AGENTS.md convention (e.g. OpenAI Codex) |
| `.cursorrules` | symlink → `CLAUDE.md` | Cursor |
| `.github/copilot-instructions.md` | symlink → `../CLAUDE.md` | GitHub Copilot ([docs](https://docs.github.com/en/copilot/how-tos/configure-custom-instructions-in-your-ide/add-repository-instructions-in-your-ide)) |

**Rationale**

- One source of truth — guidance lives in `CLAUDE.md`, the symlinks are zero-content. No drift between four files.
- Each agentic tool reads its canonical filename and gets the same content.
- Mac/Linux dev environments handle symlinks natively. Windows checkouts may render them as text files containing the target path; the canonical `CLAUDE.md` is unaffected and still rendered/served correctly by GitHub.

**Out of scope**

Path-specific Copilot instructions (`.github/instructions/*.instructions.md`) need YAML frontmatter (`applyTo:`) and target specific globs, so they cannot be symlinks. Not added here; they can be authored as separate small files per-repo if/when narrow path-scoped guidance is needed.

Tracked under [T8595](https://vyos.dev/T8595).

## Test plan

- [ ] `CLAUDE.md` renders on GitHub.
- [ ] `AGENTS.md`, `.cursorrules`, `.github/copilot-instructions.md` resolve to CLAUDE.md content (`readlink` returns the right target).
- [ ] CI passes.

🤖 Generated by [robots](https://vyos.io)
